### PR TITLE
Auto `pip install -r` All `requirements*.txt` Files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,10 @@ runs:
       shell: bash
     - run: pip install mypy
       shell: bash
-    - name: Install Dev Requirements
+    - name: Pip Install Local Package and All 'requirements*.txt' Files We Find
       run: |
-        ([ -e "requirements-dev.txt" ] && pip install -r requirements-dev.txt) || echo "no dev reqs"
-      shell: bash
-    - name: Pip Install Local Package (or All Requirements)
-      run: |
-        ([ -e "setup.py" ] && pip install .) || pip install `find . -name 'requirements.txt' | rev | sed -z 's/\n/ r- /g' | rev`
+        ([ -e "setup.py" ] && pip install .) || (echo "no setup.py")
+        pip install `find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev`
       shell: bash
     - name: Run Mypy (and Try to Install Type-Packages)
       run: |

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,8 @@ runs:
     - name: Pip Install Local Package and All 'requirements*.txt' Files We Find
       run: |
         ([ -e "setup.py" ] && pip install .) || (echo "no setup.py")
-        pip install `find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev`
+        # ex: pip install -r requirements.txt requirements-dev.txt foo/requirements.txt
+        (pip install `find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev`) || (echo "no requirements*.txt files")
       shell: bash
     - name: Run Mypy (and Try to Install Type-Packages)
       run: |


### PR DESCRIPTION
This idea here is that if there are `requirements*.txt` files, they're probably needed for mypy. Dynamic imports (see https://github.com/WIPACrepo/wipac-dev-py-setup-action/pull/22, aka install `extra_requires`) can get messy, so let's just pretend "everything" is just one big `requirements.txt`.