### PR TITLE
Separate Package- and Script-Style Dependency Installs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,22 +15,40 @@ description: 'GitHub Action Package for Running Mypy'
 runs:
   using: "composite"
   steps:
+
     - run: pip install --upgrade pip
       shell: bash
+
     - run: pip install mypy
       shell: bash
-    - name: Pip Install Local Package and All 'requirements*.txt' Files We Find
+
+    - name: pip install dependencies
       run: |
-        ([ -e "setup.py" ] && pip install .) || (echo "no setup.py")
-        # ex: pip install -r requirements.txt requirements-dev.txt foo/requirements.txt
-        (pip install `find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev`) || (echo "no requirements*.txt files")
+        #
+        # PACKAGE -> pip install (try 'mypy' extra first)
+        if [ -e "setup.py" ]; then
+          pip install .[mypy] || pip install .
+        #
+        # SCRIPT -> install all requirements*.txt files
+        elif [ -n "$(find . -name 'requirements*.txt' | head -1)" ]; then
+          # ex: pip install -r requirements.txt requirements-dev.txt foo/requirements.txt
+          pip install $(find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev)
+        #
+        # ERROR
+        else
+          echo "could not install dependencies -- did not find setup.py or requirements*.txt file(s)"
+          exit 2
+        fi
       shell: bash
-    - name: Run Mypy (and Try to Install Type-Packages)
+
+    - name: run mypy (and try to install type-packages)
       run: |
         flags="--namespace-packages --exclude build/"
         it_flags="--install-types --non-interactive"
+
         # do mypy (may fail the first time if missing 3rd party packages, second time uses mypy cache for 3rd party packages)
         (mypy $it_flags $flags -v . 2> stderr.txt) || (mypy $flags -v . 2> stderr.txt)
+
         # show which files were looked at (-v must be used to produce file names)
         grep "Found source" stderr.txt | sed "s_.*path='\(.*\)py'.*_\1py_"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         # PACKAGE -> pip install (try 'mypy' extra first)
         if [ -e "setup.py" ]; then
           echo "installing dependencies from setup.py..."
-          pip install .[mypy] || pip install .
+          pip install .[mypy]  # okay if 'mypy' extra doesn't exist (it'll just install .)
         #
         # SCRIPT -> install all requirements*.txt files
         elif [ -n "$(find . -name 'requirements*.txt' | head -1)" ]; then

--- a/action.yml
+++ b/action.yml
@@ -27,11 +27,13 @@ runs:
         #
         # PACKAGE -> pip install (try 'mypy' extra first)
         if [ -e "setup.py" ]; then
+          echo "installing dependencies from setup.py..."
           pip install .[mypy] || pip install .
         #
         # SCRIPT -> install all requirements*.txt files
         elif [ -n "$(find . -name 'requirements*.txt' | head -1)" ]; then
           # ex: pip install -r requirements.txt requirements-dev.txt foo/requirements.txt
+          echo "installing dependencies from requirements*.txt files..."
           pip install $(find . -name 'requirements*.txt' | rev | sed -z 's/\n/ r- /g' | rev)
         #
         # ERROR

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,10 @@ runs:
         # pip install dependencies
         set -x
         #
-        # PACKAGE -> pip install (try 'mypy' extra first)
+        # PACKAGE -> pip install (try 'mypy'-extra first)
         if [ -e "setup.py" ]; then
-          echo "installing dependencies from setup.py..."
-          pip install .[mypy]  # okay if 'mypy' extra doesn't exist (it'll just install .)
+          echo "installing dependencies from setup.py (will work even if 'mypy'-extra doesn't exist)..."
+          pip install .[mypy]
         #
         # SCRIPT -> install all requirements*.txt files
         elif [ -n "$(find . -name 'requirements*.txt' | head -1)" ]; then

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,8 @@ runs:
 
     - name: pip install dependencies
       run: |
+        # pip install dependencies
+        set -x
         #
         # PACKAGE -> pip install (try 'mypy' extra first)
         if [ -e "setup.py" ]; then


### PR DESCRIPTION
Major Release

- **package-style:** install via `pip install .`
	+ _**new:**_ uses `pip install .[mypy]`
				- the new dedicated `mypy` extra allows (1) finer control for user and (2) a dedicated dep log if using [wipac-dev-py-setup-action](https://github.com/WIPACrepo/wipac-dev-py-setup-action)
	+ if a `mypy` extra is not present, the package is installed as normal
- **script-style:** install via `pip install -r requirements*.txt` (multiple installs)
	+ now, this method is only used if there is no `setup.py` (aka, it's not a package)

closes https://github.com/WIPACrepo/wipac-dev-mypy-action/issues/4